### PR TITLE
Port org_unit_intersection_policy to d2/d2-ui 2.27

### DIFF
--- a/src/data-table/DataTableContextMenu.component.js
+++ b/src/data-table/DataTableContextMenu.component.js
@@ -22,9 +22,10 @@ function DataTableContextMenu(props, context) {
     const cmStyle = {
         position: 'fixed',
     };
+    const popoverProps = _.pick(props, _.keys(Popover.propTypes));
     return (
         <Popover
-            {...props}
+            {...popoverProps}
             open={Boolean(props.activeItem)}
             anchorEl={props.target}
             anchorOrigin={{ horizontal: 'middle', vertical: 'center' }}

--- a/src/org-unit-select/OrgUnitSelectByGroup.component.js
+++ b/src/org-unit-select/OrgUnitSelectByGroup.component.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import log from 'loglevel';
 
-import { addToSelection, removeFromSelection, handleChangeSelection, renderDropdown, renderControls } from './common';
+import { filterWithParentSelected, addToSelection, addToSelectionWithIntersection,
+         removeFromSelection, removeFromSelectionWithIntersection, handleChangeSelection,
+         renderDropdown, renderControls } from './common';
 
 
 class OrgUnitSelectByGroup extends React.Component {
@@ -14,8 +16,11 @@ class OrgUnitSelectByGroup extends React.Component {
         };
         this.groupCache = {};
 
+        this.filterWithParentSelected = filterWithParentSelected.bind(this);
         this.addToSelection = addToSelection.bind(this);
+        this.addToSelectionWithIntersection = addToSelectionWithIntersection.bind(this);
         this.removeFromSelection = removeFromSelection.bind(this);
+        this.removeFromSelectionWithIntersection = removeFromSelectionWithIntersection.bind(this);
         this.handleChangeSelection = handleChangeSelection.bind(this);
         this.renderControls = renderControls.bind(this);
 
@@ -73,11 +78,23 @@ class OrgUnitSelectByGroup extends React.Component {
     }
 
     handleSelect() {
-        this.getOrgUnitsForGroup(this.state.selection).then(this.addToSelection);
+        this.getOrgUnitsForGroup(this.state.selection).then(orgUnits => {
+            if (this.props.intersectionPolicy) {
+                this.addToSelectionWithIntersection(orgUnits);
+            } else {
+                this.addToSelection(orgUnits);
+            }
+        });
     }
 
     handleDeselect() {
-        this.getOrgUnitsForGroup(this.state.selection).then(this.removeFromSelection);
+        this.getOrgUnitsForGroup(this.state.selection).then(orgUnits => {
+            if (this.props.intersectionPolicy) {
+                this.removeFromSelectionWithIntersection(orgUnits);
+            } else {
+                this.removeFromSelection(orgUnits);
+            }
+        });
     }
 
     render() {
@@ -105,6 +122,9 @@ OrgUnitSelectByGroup.propTypes = {
     // Whenever the selection changes, onUpdateSelection will be called with
     // one argument: The new array of selected organisation unit paths
     onUpdateSelection: React.PropTypes.func.isRequired,
+
+    //intersectionPolicy a boolean that tells if selection must a subset of current selection or not
+    intersectionPolicy: React.PropTypes.bool,
 
     // If currentRoot is set, only org units that are descendants of the
     // current root org unit will be added to or removed from the selection

--- a/src/org-unit-select/OrgUnitSelectByLevel.component.js
+++ b/src/org-unit-select/OrgUnitSelectByLevel.component.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import log from 'loglevel';
-import { addToSelection, removeFromSelection, handleChangeSelection, renderDropdown, renderControls } from './common';
+
+import { filterWithParentSelected, addToSelection, addToSelectionWithIntersection,
+         removeFromSelection, removeFromSelectionWithIntersection, handleChangeSelection,
+         renderDropdown, renderControls } from './common';
 
 
 class OrgUnitSelectByLevel extends React.Component {
@@ -13,8 +16,11 @@ class OrgUnitSelectByLevel extends React.Component {
         };
         this.levelCache = {};
 
+        this.filterWithParentSelected = filterWithParentSelected.bind(this);
         this.addToSelection = addToSelection.bind(this);
+        this.addToSelectionWithIntersection = addToSelectionWithIntersection.bind(this);
         this.removeFromSelection = removeFromSelection.bind(this);
+        this.removeFromSelectionWithIntersection = removeFromSelectionWithIntersection.bind(this);
         this.handleChangeSelection = handleChangeSelection.bind(this);
         this.renderControls = renderControls.bind(this);
 
@@ -78,17 +84,23 @@ class OrgUnitSelectByLevel extends React.Component {
     }
 
     handleSelect() {
-        this.getOrgUnitsForLevel(this.state.selection)
-            .then(orgUnits => {
+        this.getOrgUnitsForLevel(this.state.selection).then(orgUnits => {
+            if (this.props.intersectionPolicy) {
+                this.addToSelectionWithIntersection(orgUnits);
+            } else {
                 this.addToSelection(orgUnits);
-            });
+            }
+        });
     }
 
     handleDeselect() {
-        this.getOrgUnitsForLevel(this.state.selection)
-            .then(orgUnits => {
+        this.getOrgUnitsForLevel(this.state.selection).then(orgUnits => {
+            if (this.props.intersectionPolicy) {
+                this.removeFromSelectionWithIntersection(orgUnits);
+            } else {
                 this.removeFromSelection(orgUnits);
-            });
+            }
+        });
     }
 
     render() {
@@ -120,6 +132,9 @@ OrgUnitSelectByLevel.propTypes = {
     // Whenever the selection changes, onUpdateSelection will be called with
     // one argument: The new array of selected organisation unit paths
     onUpdateSelection: React.PropTypes.func.isRequired,
+
+    //intersectionPolicy a boolean that tells if selection must a subset of current selection or not
+    intersectionPolicy: React.PropTypes.bool,
 
     // If currentRoot is set, only org units that are descendants of the
     // current root org unit will be added to or removed from the selection

--- a/src/org-unit-select/common.js
+++ b/src/org-unit-select/common.js
@@ -18,12 +18,27 @@ const style = {
 style.button1 = Object.assign({}, style.button, { marginLeft: 0 });
 
 
+function filterWithParentSelected(orgUnits) {
+    return orgUnits.filter(newOrgUnitItem => {
+        return this.props.selected.some(selectedPath => {
+            return newOrgUnitItem.path &&
+                   newOrgUnitItem.path !== selectedPath &&
+                   newOrgUnitItem.path.indexOf(selectedPath) !== -1;
+        });
+    });
+}
+
 function addToSelection(orgUnits) {
     const orgUnitArray = Array.isArray(orgUnits) ? orgUnits : orgUnits.toArray();
     const addedOus = orgUnitArray
         .filter(ou => !this.props.selected.includes(ou.path));
 
     this.props.onUpdateSelection(this.props.selected.concat(addedOus.map(ou => ou.path)));
+}
+
+function addToSelectionWithIntersection(orgUnits) {
+    const orgUnitsWithParentSelected = this.filterWithParentSelected(orgUnits);
+    this.addToSelection(orgUnitsWithParentSelected);
 }
 
 function removeFromSelection(orgUnits) {
@@ -34,6 +49,11 @@ function removeFromSelection(orgUnits) {
     const selectedOus = this.props.selected.filter(ou => !removed.includes(ou));
 
     this.props.onUpdateSelection(selectedOus);
+}
+
+function removeFromSelectionWithIntersection(orgUnits) {
+    const orgUnitsWithParentSelected = this.filterWithParentSelected(orgUnits);
+    this.removeFromSelection(orgUnitsWithParentSelected);
 }
 
 function handleChangeSelection(event) {
@@ -80,8 +100,11 @@ function renderControls() {
 }
 
 export {
+    filterWithParentSelected,
     addToSelection,
+    addToSelectionWithIntersection,
     removeFromSelection,
+    removeFromSelectionWithIntersection,
     handleChangeSelection,
     renderDropdown,
     renderControls,


### PR DESCRIPTION
Closes EyeSeeTea/organisationUnit-User-Assigment#28

Main change: now the OrgUnit components use `orgUnit.path` instead of `orgUnit.id` as the identifier.