### PR TITLE
Add dependencies and presets so module can be used as github dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-    "presets": ["stage-0", "react"],
+    "presets": ["stage-0", "react", "es2015"],
     "plugins": [
         "transform-class-properties",
         "transform-es2015-template-literals",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preversion": "npm run validate && npm test",
     "build": "npm run build-only",
     "build-only": "rm -rf lib/ && babel src --out-dir lib && compass compile && npm run build-stand-alone-header-bar",
+    "postinstall": "rm -rf lib/ && babel src --out-dir lib && compass compile",
     "prebuild-stand-alone-header-bar": "rm -rf dist &>/dev/null || true",
     "build-stand-alone-header-bar": "webpack -p && cp -r ./examples/external-header-bar/index.html dist",
     "validate": "npm ls --depth 0 || yarn list"
@@ -25,6 +26,8 @@
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "material-ui": "0.17",
+    "d3-color": "1.0.2",
+    "webpack-visualizer-plugin": "^0.1.5",
     "rxjs": "^5.2.0"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,9 @@ module.exports = {
                 test: /\.jsx?$/,
                 exclude: [/(node_modules)/],
                 loader: 'babel-loader',
+                query: {
+                    presets: ['stage-0', 'react', 'es2015'],
+                },
             },
             {
                 test: /\.css$/,


### PR DESCRIPTION
Closes EyeSeeTea/organisationUnit-User-Assigment#61
(Related PR: EyeSeeTea/organisationUnit-User-Assigment#62)

This is the same we did for the d2-ui used in dataset-configuration, it's required when the package is build from a github dependency.