### PR TITLE
Pass all arguments from Translate mixin to d2.translate so we can use namespaces

### DIFF
--- a/src/i18n/Translate.mixin.js
+++ b/src/i18n/Translate.mixin.js
@@ -5,8 +5,8 @@ const Translate = {
         d2: React.PropTypes.object.isRequired,
     },
 
-    getTranslation(key) {
-        return this.context.d2.i18n.getTranslation(key);
+    getTranslation(...args) {
+        return this.context.d2.i18n.getTranslation(...args);
     },
 };
 


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/dataset-configuration/issues/187

dhis i18n translate allows to send a namespace with vars to be interpolated, but the parameter was not passed. Now this works:

```
# i18 file
hello=Hello $$name$$

# js
this.getTranslation("hello", {name: "Mary"});
```