### PR TITLE
Feature/user extended app validate on render extensions

### DIFF
--- a/src/data-table/DataTableContextMenu.component.js
+++ b/src/data-table/DataTableContextMenu.component.js
@@ -22,7 +22,10 @@ function DataTableContextMenu(props, context) {
     const cmStyle = {
         position: 'fixed',
     };
-    const popoverProps = _.pick(props, _.keys(Popover.propTypes));
+
+    let popoverProps = {};
+    Object.keys(Popover.propTypes).forEach(key => { popoverProps[key] = props[key]; });
+
     return (
         <Popover
             {...popoverProps}

--- a/src/forms/FormBuilder.component.js
+++ b/src/forms/FormBuilder.component.js
@@ -60,6 +60,12 @@ class FormBuilder extends React.Component {
         }
     }
 
+    componentDidMount() {
+        if (this.props.validateOnInitialRender) {
+            this.validateProps(this.props);
+        }
+    }
+
     validateProps(props) {
         this.asyncValidators = this.createAsyncValidators(props);
 
@@ -422,7 +428,7 @@ class FormBuilder extends React.Component {
                 if (pass !== true) {
                     return pass;
                 } else {
-                    const validatorResult = currentValidator.validator(newValue);
+                    const validatorResult = currentValidator.validator(newValue, this.props.id);
                     return validatorResult === true ? true : (currentValidator.message || validatorResult);
                 }
             }, true);
@@ -453,6 +459,7 @@ class FormBuilder extends React.Component {
  * @type {{fields: (Object|isRequired), validatingLabelText: *, validatingProgressStyle: *, onUpdateField: (Function|isRequired)}}
  */
 FormBuilder.propTypes = {
+    id: React.PropTypes.any,
     fields: React.PropTypes.arrayOf(React.PropTypes.shape({
         name: React.PropTypes.string.isRequired,
         value: React.PropTypes.any,
@@ -478,6 +485,7 @@ FormBuilder.propTypes = {
     fieldWrapper: React.PropTypes.func,
     mainWrapper: React.PropTypes.func,
     validateOnRender: React.PropTypes.bool,
+    validateOnInitialRender: React.PropTypes.bool,
     validateFullFormOnChanges: React.PropTypes.bool,
 };
 
@@ -487,6 +495,7 @@ FormBuilder.propTypes = {
  * @type {{validatingLabelText: string, validatingProgressStyle: {position: string, right: number, top: number}}}
  */
 FormBuilder.defaultProps = {
+    id: null,
     validatingLabelText: 'Validating...',
     validatingProgressStyle: {
         position: 'absolute',
@@ -495,6 +504,7 @@ FormBuilder.defaultProps = {
     },
     onUpdateFormStatus: noop,
     validateOnRender: false,
+    validateOnInitialRender: false,
     validateFullFormOnChanges: false,
 };
 

--- a/test/forms/FormBuilder.component.test.js
+++ b/test/forms/FormBuilder.component.test.js
@@ -23,7 +23,7 @@ describe('FormBuilder component', () => {
             fields[0].value = value;
         }
 
-        formComponent = renderComponent({ fields, onUpdateField });
+        formComponent = renderComponent({ fields, onUpdateField, validateOnRender: true });
     });
 
     it('should have a asyncFieldValidator availble on the component', () => {
@@ -88,6 +88,7 @@ describe('FormBuilder component', () => {
                 fields,
                 onUpdateField: onUpdateFieldSpy,
                 onUpdateFormStatus,
+                validateOnRender: true,
             });
         });
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Required by https://github.com/EyeSeeTea/user-extended-app/issues/74

### :memo: Implementation

- Add new prop: id. It's handy to identify the ofrm when using multiple form builders and using a single onUpdate callback function.
Add new prop: `validateOnInitialRender`. Perform validation on first render (by default it's not done)
- Fixes lodash usage and test.