### PR TITLE
[org-unit-select] Check model before using it in orgUnits filters

### DIFF
--- a/src/org-unit-select/orgunit-tree-multi-select.js
+++ b/src/org-unit-select/orgunit-tree-multi-select.js
@@ -41,11 +41,18 @@ export default class OrganisationUnitTreeMultiSelect extends React.Component {
         };
 
         const { levels: levelsFilter, groups: groupsFilter } = this.props.filters || {};
+        const hasModel = this.props.model && this.props.model.id;
 
         Promise.all([
             d2.currentUser.getOrganisationUnits({
-                memberCollection: overlyComplicatedTemporaryFixForWeirdlyNamedFields(this.props.modelDefinition.plural),
-                memberObject: this.props.model.id,
+                ...(hasModel
+                    ? {
+                          memberCollection: overlyComplicatedTemporaryFixForWeirdlyNamedFields(
+                              this.props.modelDefinition.plural
+                          ),
+                          memberObject: this.props.model.id,
+                      }
+                    : {}),
                 fields: 'id,path,displayName,code,level,children::isNotEmpty',
             }),
             d2.models.organisationUnitLevels.list({


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/dataset-configuration/pull/415